### PR TITLE
Enforce unique role name.

### DIFF
--- a/src/main/java/org/cristalise/kernel/lifecycle/instance/predefined/server/CreateNewRole.java
+++ b/src/main/java/org/cristalise/kernel/lifecycle/instance/predefined/server/CreateNewRole.java
@@ -53,6 +53,8 @@ public class CreateNewRole extends PredefinedStep
 			Logger.error(e);
 			throw new InvalidDataException("CreateNewRole: Couldn't unmarshall new Role: "+requestData);
 		}
+		if (Gateway.getLookup().getRolePath(newRole.getName()).exists())
+			throw new ObjectAlreadyExistsException("Role '"+newRole.getName()+"' already exists.");
     	newRole.create(agent, true);
     	return requestData;
     }


### PR DESCRIPTION
Check in ImportRole that the same Role name hasn't been used for another subrole. Also, CreateNewRole should throw an ObjectAlreadyExistsException if the Role already exists.