### PR TITLE
AbstractMain.shutdown execution abort

### DIFF
--- a/src/main/java/org/cristalise/kernel/process/AbstractMain.java
+++ b/src/main/java/org/cristalise/kernel/process/AbstractMain.java
@@ -168,14 +168,12 @@ abstract public class AbstractMain
     public static void shutdown(int errCode) {
     	if (shutdownHandler!= null)
     		shutdownHandler.shutdown(errCode, isServer);
-    	else {
-			try {
-				Gateway.close();
-			} catch (Exception ex) {
-				Logger.error(ex);
-			}
-    	}
-		System.exit(errCode); // if we get here, we get out
+		try {
+			Gateway.close();
+		} catch (Exception ex) {
+			Logger.error(ex);
+		}
+		throw new ThreadDeath(); // if we get here, we get out
 
     }
 }


### PR DESCRIPTION
Throw a ThreadDeath Error instead of System.exit, as in other execution environments it is not convenient to stop the JVM. This should abort the
current thread. Refs #37